### PR TITLE
Changing to apps/v1 so that this works both locally and in kwest2

### DIFF
--- a/kubernetes/github-token-exchange/base/deploy.yml
+++ b/kubernetes/github-token-exchange/base/deploy.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: github-token-exchange


### PR DESCRIPTION
The old extensions/v1beta1 was deprecated a few years ago, but our clusters haven't all been upgraded. But apps/v1 has been around for a while in various k8s versions